### PR TITLE
Remove BOM (if exists) before parsing project.json file.

### DIFF
--- a/generators/app/aspnetHelper.js
+++ b/generators/app/aspnetHelper.js
@@ -76,10 +76,15 @@ AspNetHelper.prototype.addKestrelCommand = function(cb) {
             return;
         }
 
-        AspNetHelper.prototype._backupFile(fileName, backupFile);
+        // Remove BOM.
+        if (data.charCodeAt(0) === 0xFEFF) {
+            data = data.replace(/^\uFEFF/, '');
+        }
+
         data = JSON.parse(data);
 
         if (data.commands.kestrel === undefined) {
+            AspNetHelper.prototype._backupFile(fileName, backupFile);
             data.commands.kestrel = 'Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.Kestrel --server.urls http://*:' + port;
             fs.writeFile(fileName, JSON.stringify(data), function(err) {
                 if (err) {


### PR DESCRIPTION
Before parsing the JSON we need to check if BOM exists and remove it, otherwise JSON.parse call fails. 
