### PR TITLE
:art: Split app insight question into multiline text

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -286,8 +286,10 @@ function handleAppInsights(yo) {
         var q = {
             type: 'confirm',
             name: 'optIn',
-            message: 'Generator-docker would like to collect anonymized data on the options you selected to understand and improve your experience.' +
-            'To opt out later, you can delete ' + chalk.red('~/.config/configstore/' + pkg.name + '.json. ') + 'Will you help us help you and your fellow developers?',
+            message: 'Generator-docker would like to collect anonymized data\n' +
+                'on the options you selected to understand and improve your experience.\n' +
+                'To opt out later, you can delete ' + chalk.red('~/.config/configstore/' + pkg.name + '.json.\n') +
+                'Will you help us help you and your fellow developers?',
             default: true
         };
 


### PR DESCRIPTION
This commit improves readability of application insight
opt-in question splitting text into separate lines.
Resulting text has been split at before 80 column,
so all content should be readable for users - even
on some terminals without text wrap support.

Before (pretty sure it won't be visible in GitHub markdown :smile:):
```
? Generator-docker would like to collect anonymized data on the options you selected to understand and improve your experience.To opt out later, you can delete ~/.config/configstore/generator-docker.json. Will you help us help you and your fellow developers? (Y/n) 
```
After:
```
? Generator-docker would like to collect anonymized data
on the options you selected to understand and improve your experience.
To opt out later, you can delete ~/.config/configstore/generator-docker.json.
Will you help us help you and your fellow developers? (Y/n)
```
Thanks!