### PR TITLE
:arrow_up: Updates ASP.NET to RC1. Closes #34

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -69,11 +69,11 @@ function showPrompts() {
             name: 'aspNetVersion',
             message: 'Which version of ASP.NET 5 is your project using?',
             choices: [{
-                name: 'beta8',
-                value: '1.0.0-beta8'
+                name: 'rc1',
+                value: '1.0.0-rc1-final'
             }, {
-                    name: 'beta7',
-                    value: '1.0.0-beta7'
+                    name: 'beta8',
+                    value: '1.0.0-beta8'
                 }],
             when: function (answers) {
                 return answers.projectType === 'aspnet';
@@ -178,7 +178,7 @@ function handleAspNet(yo) {
     var aspNet = new AspNetHelper(aspNetVersion, portNumber, imageName);
 
     var done = yo.async();
-    aspNet.addKestrelCommand(function (err, commandAdded) {
+    aspNet.addWebCommand(function (err, commandAdded) {
         if (err) {
             error = true;
             yo.log.error(err);


### PR DESCRIPTION
This commit udpates ASP.NET 5 template to RC1
- RC1 related content is introduced
- beta7 is phased out from template
- *kestrel* is phased out from source code
and replaced with web where appropriate
- refactor addKestrelCommand to addWebCommand
- refactor tests to cover RC1 changes
- add case for RC1-UPDATE1 Docker image for RC1
- phase out getAspNetCommandName (used once)
- small refactorings related to ASP.NET helper
Thanks!