### PR TITLE
Always include both scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI Status][ciStatusBadge]][ciLink]
 [![Downloads][npmDownloadsBadge]][npmLink]
 
-This generator creates a Dockerfile and a script (`dockerTask.sh` or `dockerTask.ps1`) that helps you build and run your project inside of a Docker container. The following project types are currently supported:
+This generator creates a Dockerfile and scripts (`dockerTask.sh` and `dockerTask.ps1`) that helps you build and run your project inside of a Docker container. The following project types are currently supported:
 - ASP.NET 5.0
 - Go
 - Node.js

--- a/generators/app/aspnetHelper.js
+++ b/generators/app/aspnetHelper.js
@@ -134,14 +134,6 @@ AspNetHelper.prototype.configureUrls = function (cb) {
 }
 
 /**
- * Gets the template script name.
- * @returns {string}
- */
-AspNetHelper.prototype.getTemplateScriptName = function () {
-    return util.isWindows() ? '_dockerTaskGeneric.ps1' : '_dockerTaskGeneric.sh';
-}
-
-/**
  * Gets the template docker-compose file name.
  * @returns {string}
  */

--- a/generators/app/golangHelper.js
+++ b/generators/app/golangHelper.js
@@ -21,15 +21,6 @@ var GolangHelper = function () {
 GolangHelper.prototype.getDockerImageName = function () {
     return 'golang';
 }
-
-/**
- * Gets the template script name.
- * @returns {string}
- */
-GolangHelper.prototype.getTemplateScriptName = function () {
-    return util.isWindows() ? '_dockerTaskGeneric.ps1' : '_dockerTaskGeneric.sh';
-}
-
 /**
  * Gets the template docker-compose file name.
  * @returns {string}

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -215,8 +215,13 @@ function handleCommmonTemplates(yo, helper, templateData) {
         releaseTemplateData);
 
     yo.fs.copyTpl(
-        yo.templatePath(helper.getTemplateScriptName()),
-        yo.destinationPath(util.getDestinationScriptName()),
+        yo.templatePath('_dockerTaskGeneric.ps1'),
+        yo.destinationPath('dockerTask.ps1'),
+        templateData);
+
+    yo.fs.copyTpl(
+        yo.templatePath('_dockerTaskGeneric.sh'),
+        yo.destinationPath('dockerTask.sh'),
         templateData);
 }
 

--- a/generators/app/nodejsHelper.js
+++ b/generators/app/nodejsHelper.js
@@ -15,14 +15,6 @@ var NodejsHelper = function () {
 }
 
 /**
- * Gets the template script name.
- * @returns {string}
- */
-NodejsHelper.prototype.getTemplateScriptName = function () {
-    return util.isWindows() ? '_dockerTaskGeneric.ps1' : '_dockerTaskGeneric.sh';
-}
-
-/**
  * Gets the template docker-compose file name.
  * @returns {string}
  */

--- a/test/aspnettests.js
+++ b/test/aspnettests.js
@@ -125,17 +125,15 @@ describe('ASP.NET RC1 project file creation', function () {
         done();
     });
 
-    it('generates dockertask file', function (done) {
-        assert.file(os.platform() === 'win32' ? 'dockerTask.ps1' : 'dockerTask.sh');
+    it('generates dockertask files', function (done) {
+        assert.file('dockerTask.ps1');
+        assert.file('dockerTask.sh');
         done();
     });
 
-    it('web project variable is set correctly in script file', function (done) {
-        if (os.platform() === 'win32') {
-            assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
-        } else {
-            assert.fileContent('dockerTask.sh', 'isWebProject=true');
-        }
+    it('OpenSite is included in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', 'OpenSite');
+        assert.fileContent('dockerTask.sh', 'openSite');
         done();
     });
 
@@ -206,16 +204,14 @@ describe('ASP.NET RC2 project file creation', function () {
     });
 
     it('generates dockertask file', function (done) {
-        assert.file(os.platform() === 'win32' ? 'dockerTask.ps1' : 'dockerTask.sh');
+        assert.file('dockerTask.ps1');
+        assert.file('dockerTask.sh');
         done();
     });
 
-    it('web project variable is set correctly in script file', function (done) {
-        if (os.platform() === 'win32') {
-            assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
-        } else {
-            assert.fileContent('dockerTask.sh', 'isWebProject=true');
-        }
+    it('OpenSite is included in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', 'OpenSite');
+        assert.fileContent('dockerTask.sh', 'openSite');
         done();
     });
 

--- a/test/aspnettests.js
+++ b/test/aspnettests.js
@@ -134,6 +134,7 @@ describe('ASP.NET RC1 project file creation', function () {
     it('web project variable is set correctly in script file', function (done) {
         assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
         assert.fileContent('dockerTask.sh', 'isWebProject=true');
+        done();
     });
 
     it('correct dockerfile contents (debug)', function (done) {
@@ -211,6 +212,7 @@ describe('ASP.NET RC2 project file creation', function () {
     it('web project variable is set correctly in script file', function (done) {
         assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
         assert.fileContent('dockerTask.sh', 'isWebProject=true');
+        done();
     });
 
     it('correct dockerfile contents (debug)', function (done) {

--- a/test/aspnettests.js
+++ b/test/aspnettests.js
@@ -131,10 +131,9 @@ describe('ASP.NET RC1 project file creation', function () {
         done();
     });
 
-    it('OpenSite is included in script file', function (done) {
-        assert.fileContent('dockerTask.ps1', 'OpenSite');
-        assert.fileContent('dockerTask.sh', 'openSite');
-        done();
+    it('web project variable is set correctly in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
+        assert.fileContent('dockerTask.sh', 'isWebProject=true');
     });
 
     it('correct dockerfile contents (debug)', function (done) {
@@ -209,10 +208,9 @@ describe('ASP.NET RC2 project file creation', function () {
         done();
     });
 
-    it('OpenSite is included in script file', function (done) {
-        assert.fileContent('dockerTask.ps1', 'OpenSite');
-        assert.fileContent('dockerTask.sh', 'openSite');
-        done();
+    it('web project variable is set correctly in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
+        assert.fileContent('dockerTask.sh', 'isWebProject=true');
     });
 
     it('correct dockerfile contents (debug)', function (done) {

--- a/test/golangtests.js
+++ b/test/golangtests.js
@@ -36,7 +36,7 @@ describe('Golang project file creation (non Web project)', function () {
         done();
     });
 
-    it('OpenSite is not included in script file', function (done) {
+    it('web project variable is set correctly in script file', function (done) {
         assert.fileContent('dockerTask.ps1', '$isWebProject=$false');
         assert.fileContent('dockerTask.sh', 'isWebProject=false');
         done();
@@ -100,7 +100,7 @@ describe('Golang project file creation (Web project)', function () {
         done();
     });
 
-    it('OpenSite is included in script file', function (done) {
+    it('web project variable is set correctly in script file', function (done) {
         assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
         assert.fileContent('dockerTask.sh', 'isWebProject=true');
         done();

--- a/test/golangtests.js
+++ b/test/golangtests.js
@@ -31,16 +31,14 @@ describe('Golang project file creation (non Web project)', function () {
     });
 
     it('generates dockertask file', function (done) {
-        assert.file(os.platform() === 'win32' ? 'dockerTask.ps1' : 'dockerTask.sh');
+        assert.file('dockerTask.ps1');
+        assert.file('dockerTask.sh');
         done();
     });
 
-    it('web project variable is set correctly in script file', function (done) {
-        if (os.platform() === 'win32') {
-            assert.fileContent('dockerTask.ps1', '$isWebProject=$false');
-        } else {
-            assert.fileContent('dockerTask.sh', 'isWebProject=false');
-        }
+    it('OpenSite is not included in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', '$isWebProject=$false');
+        assert.fileContent('dockerTask.sh', 'isWebProject=false');
         done();
     });
 
@@ -97,16 +95,14 @@ describe('Golang project file creation (Web project)', function () {
     });
 
     it('generates dockertask file', function (done) {
-        assert.file(os.platform() === 'win32' ? 'dockerTask.ps1' : 'dockerTask.sh');
+        assert.file('dockerTask.ps1');
+        assert.file('dockerTask.sh');
         done();
     });
 
-    it('web project variable is set correctly in script file', function (done) {
-        if (os.platform() === 'win32') {
-            assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
-        } else {
-            assert.fileContent('dockerTask.sh', 'isWebProject=true');
-        }
+    it('OpenSite is included in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
+        assert.fileContent('dockerTask.sh', 'isWebProject=true');
         done();
     });
 

--- a/test/nodejstests.js
+++ b/test/nodejstests.js
@@ -31,16 +31,14 @@ describe('Node.js project file creation', function () {
     });
 
     it('generates dockertask file', function (done) {
-        assert.file(os.platform() === 'win32' ? 'dockerTask.ps1' : 'dockerTask.sh');
+        assert.file('dockerTask.ps1');
+        assert.file('dockerTask.sh');
         done();
     });
 
-    it('web project variable is set correctly in script file', function (done) {
-        if (os.platform() === 'win32') {
-            assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
-        } else {
-            assert.fileContent('dockerTask.sh', 'isWebProject=true');
-        }
+    it('OpenSite is included in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', 'OpenSite');
+        assert.fileContent('dockerTask.sh', 'openSite');
         done();
     });
 

--- a/test/nodejstests.js
+++ b/test/nodejstests.js
@@ -36,10 +36,9 @@ describe('Node.js project file creation', function () {
         done();
     });
 
-    it('OpenSite is included in script file', function (done) {
-        assert.fileContent('dockerTask.ps1', 'OpenSite');
-        assert.fileContent('dockerTask.sh', 'openSite');
-        done();
+    it('web project variable is set correctly in script file', function (done) {
+        assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
+        assert.fileContent('dockerTask.sh', 'isWebProject=true');
     });
 
     it('correct dockerfile contents (debug)', function (done) {

--- a/test/nodejstests.js
+++ b/test/nodejstests.js
@@ -39,6 +39,7 @@ describe('Node.js project file creation', function () {
     it('web project variable is set correctly in script file', function (done) {
         assert.fileContent('dockerTask.ps1', '$isWebProject=$true');
         assert.fileContent('dockerTask.sh', 'isWebProject=true');
+        done();
     });
 
     it('correct dockerfile contents (debug)', function (done) {


### PR DESCRIPTION
Change to always include both scripts to better support cross-platform
development with scaffolded files.