### PR TITLE
Fix use of configuration in dotnet run

### DIFF
--- a/generators/app/templates/dotnet/Dockerfile
+++ b/generators/app/templates/dotnet/Dockerfile
@@ -5,4 +5,4 @@ RUN ["dotnet", "restore"]
 COPY . /app
 RUN ["dotnet", "build", "-c", "<%= environment %>"]
 EXPOSE <%= portNumber %>
-ENTRYPOINT ["dotnet", "run"]
+ENTRYPOINT ["dotnet", "run", "-c", "<%= environment %>"]

--- a/test/aspnettests.js
+++ b/test/aspnettests.js
@@ -228,16 +228,18 @@ describe('ASP.NET RC2 project file creation', function () {
     it('correct dockerfile contents (debug)', function (done) {
         assert.fileContent('Dockerfile.debug', 'FROM microsoft/dotnet:1.0.0-preview1');
         assert.fileContent('Dockerfile.debug', 'RUN ["dotnet", "restore"]');
+        assert.fileContent('Dockerfile.debug', 'RUN ["dotnet", "build", "-c", "debug"]');
         assert.fileContent('Dockerfile.debug', 'EXPOSE 5000');
-        assert.fileContent('Dockerfile.release', 'ENTRYPOINT ["dotnet", "run"');
+        assert.fileContent('Dockerfile.debug', 'ENTRYPOINT ["dotnet", "run", "-c", "debug"]');
         done();
     });
 
     it('correct dockerfile contents (release)', function (done) {
         assert.fileContent('Dockerfile.release', 'FROM microsoft/dotnet:1.0.0-preview1');
-        assert.fileContent('Dockerfile.debug', 'RUN ["dotnet", "restore"]');
+        assert.fileContent('Dockerfile.release', 'RUN ["dotnet", "restore"]');
+        assert.fileContent('Dockerfile.release', 'RUN ["dotnet", "build", "-c", "release"]');
         assert.fileContent('Dockerfile.release', 'EXPOSE 5000');
-        assert.fileContent('Dockerfile.release', 'ENTRYPOINT ["dotnet", "run"');
+        assert.fileContent('Dockerfile.release', 'ENTRYPOINT ["dotnet", "run", "-c", "release"]');
         done();
     });
 


### PR DESCRIPTION
Change dotnet run to use the same configuration as dotnet build. Also
update the tests to verify the configuration used in each dockerfile.