### PR TITLE
Add sanitization of compose project name from user, not just the suggestion

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -126,7 +126,7 @@ function showPrompts() {
         imageName = props.imageName;
         serviceName = props.serviceName;
         baseImageName = props.baseImageName;
-        composeProjectName = props.composeProjectName;
+        composeProjectName = props.composeProjectName.replace(/[^a-zA-Z0-9]/g, '');
         done();
     }.bind(this));
 }


### PR DESCRIPTION
Fix for #106: docker-compose does not support having a - in the project name, the generator has been updated to strip them from the string provided by the user (consistent with docker-compose’s behavior)