### PR TITLE
Removing --head to enable OpenSite to work

### DIFF
--- a/generators/app/templates/_dockerTaskGeneric.sh
+++ b/generators/app/templates/_dockerTaskGeneric.sh
@@ -90,7 +90,7 @@ startDebugging () {<% if (isWebProject) { %>
 
 openSite () {
   printf 'Opening site'
-  until $(curl --output /dev/null --silent --head --fail $url); do
+  until $(curl --output /dev/null --silent --fail $url); do
     printf '.'
     sleep 1
   done


### PR DESCRIPTION
—head was causing the website to not open. It is a Kestrel issue. It
does not support —head anymore evidently. Removed it form sh script.