### PR TITLE
Add options to generator-docker

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -498,13 +498,13 @@ var DockerGenerator = yeoman.generators.Base.extend({
         this.option('serviceName', {
             type: String,
             required: false,
-            desc: 'serviceName'
+            desc: 'Service Name'
         });
 
         this.option('composeProjectName', {
             type: String,
             required: false,
-            desc: 'composeProjectName'
+            desc: 'Compose Project Name'
         });
     },
 
@@ -512,7 +512,9 @@ var DockerGenerator = yeoman.generators.Base.extend({
         this.log(yosay('Welcome to the ' + chalk.red('Docker') + ' generator!' + chalk.green('\nLet\'s add Docker container magic to your app!')));
         handleAppInsights(this);
     },
+
     askFor: showPrompts,
+
     writing: function () {
         this.sourceRoot(path.join(__dirname, './templates'));
         switch (projectType) {
@@ -536,6 +538,7 @@ var DockerGenerator = yeoman.generators.Base.extend({
                 break;
         }
     },
+
     end: end
 });
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -57,6 +57,7 @@ function showPrompts() {
         type: 'list',
         name: 'projectType',
         message: 'What language is your project using?',
+        when: !projectType,
         choices: [{
             name: '.NET Core',
             value: 'dotnet'
@@ -438,10 +439,19 @@ function handleAppInsights(yo) {
 var DockerGenerator = yeoman.generators.Base.extend({
     constructor: function () {
         yeoman.generators.Base.apply(this, arguments);
+
+        this.option('projectType', {
+            type: String,
+            required: false,
+            desc: 'Project Type'
+        });
     },
 
     init: function () {
         this.log(yosay('Welcome to the ' + chalk.red('Docker') + ' generator!' + chalk.green('\nLet\'s add Docker container magic to your app!')));
+
+        projectType = this.options.projectType;
+
         handleAppInsights(this);
     },
     askFor: showPrompts,
@@ -464,7 +474,7 @@ var DockerGenerator = yeoman.generators.Base.extend({
                     break;
                 }
             default:
-                this.log.error(':( not implemented.');
+                this.log.error(projectType + ' generator not implemented.');
                 break;
         }
     },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -102,7 +102,8 @@ function showPrompts() {
         },
         when: function (answers) {
             // Show this answer if user picked .NET, Node.js or Golang that's using a web server.
-            return answers.isWebProject || this.options.isWebProject;
+            if (this.options.portNumber) return false;
+            return (answers.isWebProject || this.options.isWebProject);
         }.bind(this)
     }, {
         type: 'input',
@@ -130,7 +131,10 @@ function showPrompts() {
           isWebProject = props.isWebProject;
         }
 
-        portNumber = props.portNumber;
+        if(props.portNumber !== undefined) {
+          portNumber = props.portNumber;
+        }
+
         imageName = props.imageName;
         serviceName = props.serviceName;
         baseImageName = props.baseImageName;
@@ -458,6 +462,12 @@ var DockerGenerator = yeoman.generators.Base.extend({
             required: false,
             desc: 'Add Web Project Configuration'
         });
+
+        this.option('portNumber', {
+            type: Number,
+            required: false,
+            desc: 'Port Number'
+        });
     },
 
     init: function () {
@@ -465,6 +475,7 @@ var DockerGenerator = yeoman.generators.Base.extend({
 
         projectType = this.options.projectType;
         isWebProject = Boolean(this.options.isWebProject);
+        portNumber = this.options.portNumber;
 
         handleAppInsights(this);
     },


### PR DESCRIPTION
Add options to generator-docker

If an option is defined for a property, do not prompt the user for the property and use option value.

you can pass options directly from CLI, like:
`yo docker --projectType=nodejs --portNumber=8000`
or you can pass them from a composed generator. 

#123 
